### PR TITLE
Issue 13

### DIFF
--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
@@ -898,7 +898,7 @@ public interface EasyTeleportsConfig extends Config
 	@ConfigItem(
 			keyName = "replacementKastori",
 			name = "Kastori",
-			description = "Replace Kastori (north of Tlati Rainforest)",
+			description = "Replace Kastori (east of Tlati Rainforest)",
 			section = SECTION_PENDANT_OF_ATES,
 			position = POSITION_PENDANT_OF_ATES + 5
 	)

--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
@@ -895,6 +895,30 @@ public interface EasyTeleportsConfig extends Config
 		return "<col=8800ff>Mastering Mixology</col>";
 	}
 
+	@ConfigItem(
+			keyName = "replacementKastori",
+			name = "Kastori",
+			description = "Replace Kastori (north of Tlati Rainforest)",
+			section = SECTION_PENDANT_OF_ATES,
+			position = POSITION_PENDANT_OF_ATES + 5
+	)
+	default String replacementKastori()
+	{
+		return "<col=65684f>Gemstone Crab</col>";
+	}
+
+	@ConfigItem(
+			keyName = "replacementNemusRetreat",
+			name = "Nemus Retreat",
+			description = "Replace Nemus Retreat (south of Auburnvale)",
+			section = SECTION_PENDANT_OF_ATES,
+			position = POSITION_PENDANT_OF_ATES + 6
+	)
+	default String replacementNemusRetreat()
+	{
+		return "<col=80b37c>Vale Totems</col>";
+	}
+
 	//
 	// END of Pendant of Ates //
 	//

--- a/src/main/java/com/duckblade/osrs/easyteleports/replacers/PendantOfAtes.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/replacers/PendantOfAtes.java
@@ -33,15 +33,19 @@ public class PendantOfAtes implements Replacer
 		this.enabled = config.enablePendantOfAtes();
 		replacements.clear();
 
-		replacements.add(new TeleportReplacement("1: The Darkfrost", "1: " + config.replacementDarkfrost()));
-		replacements.add(new TeleportReplacement("<col=ffffff>1: The Darkfrost</col>", "1: " + config.replacementDarkfrost()));
-		replacements.add(new TeleportReplacement("The Darkfrost", config.replacementDarkfrost()));
+		replacements.add(new TeleportReplacement("1: Darkfrost", "1: " + config.replacementDarkfrost()));
+		replacements.add(new TeleportReplacement("<col=ffffff>1: Darkfrost</col>", "1: " + config.replacementDarkfrost()));
+		replacements.add(new TeleportReplacement("Darkfrost", config.replacementDarkfrost()));
 		replacements.add(new TeleportReplacement("2: Twilight Temple", "2: " + config.replacementTwilightTemple()));
 		replacements.add(new TeleportReplacement("Twilight Temple", config.replacementTwilightTemple()));
 		replacements.add(new TeleportReplacement("3: Ralos' Rise", "3: " + config.replacementRalosRise()));
 		replacements.add(new TeleportReplacement("Ralos' Rise", config.replacementRalosRise()));
 		replacements.add(new TeleportReplacement("4: North Aldarin", "4: " + config.replacementNorthAldarin()));
 		replacements.add(new TeleportReplacement("North Aldarin", config.replacementNorthAldarin()));
+		replacements.add(new TeleportReplacement("5: Kastori", "5: " + config.replacementKastori()));
+		replacements.add(new TeleportReplacement("Kastori", config.replacementKastori()));
+		replacements.add(new TeleportReplacement("6: Nemus Retreat", "6: " + config.replacementNemusRetreat()));
+		replacements.add(new TeleportReplacement("Nemus Retreat", config.replacementNemusRetreat()));
 	}
 
 	@Override


### PR DESCRIPTION
Closes issue https://github.com/DapperMickie/easy-teleports/issues/13

## Fixes Darkfrost replacement option not working
- Replaced "**The Darkfrost**" with "**Darkfrost**", which seems to be the updated menu entry in game.
<img width="209" height="127" alt="image" src="https://github.com/user-attachments/assets/1ae40c9a-f03f-4d83-9c14-e4edbf5fab2b" />

## Includes two new teleport replacement options for the Pendant of Ates, added July 23rd with Varlamore Pt. 3
- **Kastori**
  - default replacement set to `<col=65684f>Gemstone Crab</col>`
- **Nemus Retreat**
  - default replacement set to `<col=80b37c>Vale Totems</col>`

Default replacement colors were grabbed directly from Gemstone Crab & Vale Totem to be distinct enough from the other existing replacement default colors.

<img width="173" height="174" alt="image" src="https://github.com/user-attachments/assets/6ffc2ba6-3b2b-413c-8607-ab00fce9c2d3" />