### PR TITLE
Add Red Rock teleport replacement

### DIFF
--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsConfig.java
@@ -2331,6 +2331,17 @@ public interface EasyTeleportsConfig extends Config {
         return "";
     }
 
+    @ConfigItem(
+            keyName = "replacementSailorsRedRock",
+            name = "Red Rock",
+            description = "Replace Red Rock teleport location name.",
+            section = SECTION_SAILORS_AMULET,
+            position = POSITION_SAILORS_AMULET + 4
+    )
+    default String replacementSailorsRedRock() {
+        return "";
+    }
+
     // Fairy Ring
     @ConfigItem(
             section = SECTION_ENABLE_FLAGS,

--- a/src/main/java/com/duckblade/osrs/easyteleports/replacers/other/SailorsAmulet.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/replacers/other/SailorsAmulet.java
@@ -21,7 +21,7 @@ public class SailorsAmulet implements Replacer
 
 	private static final String SAILORS_AMULET_DIALOGUE_HEADER = "Where would you like to teleport to?";
 
-	private final List<TeleportReplacement> replacements = new ArrayList<>(6);
+	private final List<TeleportReplacement> replacements = new ArrayList<>(8);
 
 	@Getter(onMethod = @__(@Override))
 	private boolean enabled = false;
@@ -38,6 +38,8 @@ public class SailorsAmulet implements Replacer
 		replacements.add(new TeleportReplacement("Port Roberts.", config.replacementSailorsPortRoberts()));
 		replacements.add(new TeleportReplacement("Deepfin Point", config.replacementSailorsDeepfinPoint()));
 		replacements.add(new TeleportReplacement("Deepfin Point.", config.replacementSailorsDeepfinPoint()));
+		replacements.add(new TeleportReplacement("Red Rock", config.replacementSailorsRedRock()));
+		replacements.add(new TeleportReplacement("Red Rock.", config.replacementSailorsRedRock()));
 	}
 
 	@Override


### PR DESCRIPTION
Summary:
- Adds a Red Rock rename setting for the Sailors' amulet.
- Applies the configured name to dialogue and direct menu entries.

Closes #47

Testing: .\gradlew.bat clean build