### PR TITLE
Fix fairy ring menu entry replacements and coloring

### DIFF
--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
@@ -499,7 +499,19 @@ public class EasyTeleportsPlugin extends Plugin
 			String formattedReplacement = mapped;
 			if (!mapped.toUpperCase(java.util.Locale.ROOT).contains(codeUpper))
 			{
-				formattedReplacement = mapped + " (" + code + ")";
+				int lastClosingTag = mapped.lastIndexOf("</col>");
+				if (lastClosingTag >= 0)
+				{
+					formattedReplacement = mapped.substring(0, lastClosingTag) + " (" + code + ")" + mapped.substring(lastClosingTag);
+				}
+				else if (mapped.contains("<col="))
+				{
+					formattedReplacement = mapped + " (" + code + ")</col>";
+				}
+				else
+				{
+					formattedReplacement = mapped + " (" + code + ")";
+				}
 			}
 
 			String optTrimmed = Text.removeTags(option).trim();

--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
@@ -66,9 +66,6 @@ public class EasyTeleportsPlugin extends Plugin
 
 	private static final int ACTION_PARAM_1_INVENTORY = InterfaceID.Inventory.ITEMS;
 
-	private static final int ACTION_PARAM_0_FAIRYRING = 49;
-	private static final int ACTION_PARAM_1_FAIRYRING = 48;
-
 	private static final int GROUP_ID_JEWELLERY_BOX = 590;
 
 	@Inject
@@ -418,16 +415,16 @@ public class EasyTeleportsPlugin extends Plugin
 			return;
 		}
 
-		if (e.getActionParam0() == ACTION_PARAM_0_FAIRYRING && e.getActionParam1() == ACTION_PARAM_1_FAIRYRING)
+		if (isFairyRingEntry(menuEntry))
 		{
 			List<TeleportReplacement> applicableReplacements =
-					getApplicableReplacements(r -> r.isApplicableToFairyRing(e.getMenuEntry().getOption()));
+					getApplicableReplacements(r -> r.isApplicableToFairyRing(menuEntry.getOption()));
 
-			applyReplacement(applicableReplacements,
-					e.getMenuEntry(),
+			clientThread.invokeLater(() -> applyReplacement(applicableReplacements,
+					menuEntry,
 					MenuEntry::getOption,
-					MenuEntry::setTarget,
-					/* shadowedText = */ false);
+					MenuEntry::setOption,
+					/* shadowedText = */ false));
 			return;
 		}
 
@@ -461,6 +458,14 @@ public class EasyTeleportsPlugin extends Plugin
 				continue;
 			}
 
+			if (isFairyRingEntry(me))
+			{
+				List<TeleportReplacement> reps =
+						getApplicableReplacements(r -> r.isApplicableToFairyRing(me.getOption()));
+				applyReplacement(reps, me, MenuEntry::getOption, MenuEntry::setOption, false);
+				continue;
+			}
+
 			EquipmentInventorySlot slot = ACTION_PARAM_1_TO_EQUIPMENT_SLOT.get(me.getParam1());
 			if (slot != null)
 			{
@@ -471,6 +476,25 @@ public class EasyTeleportsPlugin extends Plugin
 		}
 
 		client.setMenuEntries(entries);
+	}
+
+	private static boolean isFairyRingEntry(MenuEntry entry)
+	{
+		if (entry == null)
+		{
+			return false;
+		}
+
+		String target = Text.removeTags(entry.getTarget());
+		if (target == null || target.isEmpty())
+		{
+			return false;
+		}
+
+		String targetLower = target.trim().toLowerCase(java.util.Locale.ROOT);
+		return targetLower.contains("fairy ring")
+			|| targetLower.contains("fairy tree")
+			|| targetLower.equals("tree & ring");
 	}
 
 	private static boolean isInventoryEntry(MenuEntry entry)
@@ -572,7 +596,7 @@ public class EasyTeleportsPlugin extends Plugin
 					matched = true;
 					useWholeLineReplace = true;
 				}
-				else if (isWidget)
+				else
 				{
 					String tokenRegex = "(^|" + sep + ")"
 							+ java.util.regex.Pattern.quote(normalizedOriginal)

--- a/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/EasyTeleportsPlugin.java
@@ -417,14 +417,7 @@ public class EasyTeleportsPlugin extends Plugin
 
 		if (isFairyRingEntry(menuEntry))
 		{
-			List<TeleportReplacement> applicableReplacements =
-					getApplicableReplacements(r -> r.isApplicableToFairyRing(menuEntry.getOption()));
-
-			clientThread.invokeLater(() -> applyReplacement(applicableReplacements,
-					menuEntry,
-					MenuEntry::getOption,
-					MenuEntry::setOption,
-					/* shadowedText = */ false));
+			clientThread.invokeLater(() -> applyFairyRingReplacement(menuEntry));
 			return;
 		}
 
@@ -460,9 +453,7 @@ public class EasyTeleportsPlugin extends Plugin
 
 			if (isFairyRingEntry(me))
 			{
-				List<TeleportReplacement> reps =
-						getApplicableReplacements(r -> r.isApplicableToFairyRing(me.getOption()));
-				applyReplacement(reps, me, MenuEntry::getOption, MenuEntry::setOption, false);
+				applyFairyRingReplacement(me);
 				continue;
 			}
 
@@ -476,6 +467,56 @@ public class EasyTeleportsPlugin extends Plugin
 		}
 
 		client.setMenuEntries(entries);
+	}
+
+	private void applyFairyRingReplacement(MenuEntry entry)
+	{
+		String option = entry.getOption();
+		if (Strings.isNullOrEmpty(option))
+		{
+			return;
+		}
+
+		List<TeleportReplacement> replacements = getApplicableReplacements(r -> r instanceof FairyRing);
+		String strippedOption = Text.removeTags(option).toUpperCase(java.util.Locale.ROOT);
+
+		for (TeleportReplacement replacement : replacements)
+		{
+			String code = replacement.getOriginal();
+			String mapped = replacement.getReplacement();
+			if (Strings.isNullOrEmpty(code) || isBlankReplacement(mapped))
+			{
+				continue;
+			}
+
+			String codeUpper = code.toUpperCase(java.util.Locale.ROOT);
+			String tokenRegex = "(^|[\\s\\-–—:|/()\\[\\],·]+)" + java.util.regex.Pattern.quote(codeUpper) + "($|[\\s\\-–—:|/()\\[\\],·]+)";
+			if (!strippedOption.matches(".*" + tokenRegex + ".*"))
+			{
+				continue;
+			}
+
+			String formattedReplacement = mapped;
+			if (!mapped.toUpperCase(java.util.Locale.ROOT).contains(codeUpper))
+			{
+				formattedReplacement = mapped + " (" + code + ")";
+			}
+
+			String optTrimmed = Text.removeTags(option).trim();
+			if (optTrimmed.toLowerCase(java.util.Locale.ROOT).startsWith("last-destination"))
+			{
+				entry.setOption("Last-destination (" + formattedReplacement + ")");
+			}
+			else if (optTrimmed.toLowerCase(java.util.Locale.ROOT).startsWith("ring-"))
+			{
+				entry.setOption("Ring-" + formattedReplacement);
+			}
+			else
+			{
+				entry.setOption(formattedReplacement);
+			}
+			break;
+		}
 	}
 
 	private static boolean isFairyRingEntry(MenuEntry entry)

--- a/src/main/java/com/duckblade/osrs/easyteleports/replacers/other/FairyRing.java
+++ b/src/main/java/com/duckblade/osrs/easyteleports/replacers/other/FairyRing.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.runelite.client.util.Text;
 
 @Singleton
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
@@ -166,11 +167,17 @@ public class FairyRing implements Replacer
 	}
 
 	@Override
-	public boolean isApplicableToFairyRing(String code)
+	public boolean isApplicableToFairyRing(String option)
 	{
+		if (option == null)
+		{
+			return false;
+		}
+
+		String strippedOption = Text.removeTags(option).toUpperCase(java.util.Locale.ROOT);
 		for (String fairyRingCode : FAIRY_RING_CODES)
 		{
-			if (fairyRingCode.equals(code + " Fairy ring") || fairyRingCode.equals(code))
+			if (strippedOption.contains(fairyRingCode))
 			{
 				return true;
 			}


### PR DESCRIPTION
Fixes #49

### Summary of Changes:
- **Target identification**: Replaced hardcoded scene tile coordinate checks with \isFairyRingEntry(entry)\, supporting all fairy rings across the game world including POH fairy rings and Spirit tree & fairy ring combinations.
- **Option replacement**: Corrected \pplyReplacement\ on fairy rings to update the menu entry's option (\setOption\) rather than overwriting the target.
- **Code matching**: Fixed \isApplicableToFairyRing\ in \FairyRing.java\ to check if the menu option contains the fairy ring code (e.g., favorite entries, \Last-destination (CODE)\, \Ring-CODE\).
- **Post-menu sorting**: Added fairy ring replacement handling in \onPostMenuSort\ to ensure custom names and color tags persist after menu sorting.
- **Token replacement**: Enabled token matching in \pplyReplacement\ for menu entries so combined strings like \Last-destination (CODE)\ have the code replaced and colored appropriately.